### PR TITLE
Update GitHub workflows to checkout@v6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Check out Source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: "true"
       - name: test
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Check out Source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: "true"
       - name: Swiftlint


### PR DESCRIPTION
This fixes a node20 warning